### PR TITLE
fix 20 accounts limit

### DIFF
--- a/python/iam-credential-report-code.py
+++ b/python/iam-credential-report-code.py
@@ -19,8 +19,13 @@ s3 = boto3.resource('s3')
 bucketName = BUCKET_ARN.split(":", -1)[-1]
 bucketConnection = s3.Bucket(bucketName)
 
-listedAccounts = orgClient.list_accounts()
+paginator = orgClient.get_paginator('list_accounts')
+page_iterator = paginator.paginate()
 
+listedAccounts = []
+for page in page_iterator:        
+    for acct in page['Accounts']:
+        listedAccounts.append(acct)
 
 failedAccounts = []
 


### PR DESCRIPTION
fixing 20 accounts limit

by default list_accounts only returns some default amount of [accounts](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/organizations.html#Organizations.Client.list_accounts)

In my case i was able to get only reports for 20 accounts, adding pagination to lambda has fixed it


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
